### PR TITLE
configuration.toml: update to more modern settings

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -2,15 +2,15 @@
   LogLevel = 'INFO'
 
 [Service]
-  BootTimeout = 30000
-  ClientMonitor = 15000
+  BootTimeout = "30s"
   CheckInterval = '10s'
+  ServerBindAddr = ''
   Host = 'localhost'
   Port = 48095
   Protocol = 'http'
   ReadMaxLimit = 100
   StartupMsg = 'Sends data from EdgeX to InfluxDB'
-  Timeout = 5000
+  Timeout = "5s"
 
 [Registry]
   Host = 'localhost'
@@ -22,7 +22,7 @@
     Protocol = 'http'
     Host = 'localhost'
     Port = 48080
-  
+
 [MessageBus]
   Type = 'zero'
   [MessageBus.PublishHost]


### PR DESCRIPTION
Some of these things need to be strings now, and specifying ServerBindAddr is
supposed to help with binding to localhost.

However, even with this configuration.toml, the service still fails like so:

2021-05-19T02: 55:20Z edgex-influx-proxy.influxproxy[133166]: level=INFO ts=2021-05-19T02:55:20.390915451Z app=edgex-influx-proxy source=sdk.go:358 msg="Starting edgex-influx-proxy 0.0.0 "
2021-05-19T02: 55:20Z edgex-influx-proxy.influxproxy[133166]: level=INFO ts=2021-05-19T02:55:20.391510291Z app=edgex-influx-proxy source=config.go:193 msg="Loaded configuration from /var/snap/edgex-influx-proxy/x1/config/edgex-influx-proxy/res/configuration.toml"
2021-05-19T02: 55:20Z edgex-influx-proxy.influxproxy[133166]: level=INFO ts=2021-05-19T02:55:20.392776115Z app=edgex-influx-proxy source=config.go:113 msg="Config Provider URL created from Registry configuration"
2021-05-19T02: 55:20Z edgex-influx-proxy.influxproxy[133166]: level=INFO ts=2021-05-19T02:55:20.392810581Z app=edgex-influx-proxy source=config.go:168 msg="Using Configuration provider (consul) from: http://localhost:8500 with base path of edgex/appservices/1.0/edgex-influx-proxy"
2021-05-19T02: 55:20Z edgex-influx-proxy.influxproxy[133166]: level=INFO ts=2021-05-19T02:55:20.401275788Z app=edgex-influx-proxy source=config.go:304 msg="Configuration has been pulled from Configuration provider (0 envVars overrides applied)"
2021-05-19T02: 55:20Z edgex-influx-proxy.influxproxy[133166]: level=INFO ts=2021-05-19T02:55:20.401380767Z app=edgex-influx-proxy source=registry.go:80 msg="Using Registry (consul) from http://localhost:8500"
2021-05-19T02: 55:20Z edgex-influx-proxy.influxproxy[133166]: level=WARN ts=2021-05-19T02:55:20.405124637Z app=edgex-influx-proxy source=registry.go:140 msg="could not register service with Registry: unable to register service with consul: Service information not set"
2021-05-19T02: 55:21Z edgex-influx-proxy.influxproxy[133166]: level=WARN ts=2021-05-19T02:55:21.410109788Z app=edgex-influx-proxy source=registry.go:140 msg="could not register service with Registry: unable to register service with consul: Service information not set"